### PR TITLE
Load .env with interpolation

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -6,6 +6,9 @@ import logging
 from fastapi import HTTPException, Security
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 
+from app.env import load_env
+load_env()
+
 logger = logging.getLogger('ha_cursor_agent')
 
 # Security
@@ -56,4 +59,5 @@ async def verify_token(credentials: HTTPAuthorizationCredentials = Security(secu
             raise HTTPException(status_code=401, detail="Invalid authentication token")
         logger.info(f"✅ Token validated in development mode")
         return token
+
 

--- a/app/env.py
+++ b/app/env.py
@@ -1,0 +1,24 @@
+"""
+Environment loading helpers.
+"""
+from __future__ import annotations
+
+import os
+from dotenv import load_dotenv
+
+_LOADED = False
+
+
+def load_env() -> None:
+    """Load .env once, supporting optional ENV_FILE override."""
+    global _LOADED
+    if _LOADED:
+        return
+
+    env_file = os.getenv("ENV_FILE")
+    if env_file:
+        load_dotenv(dotenv_path=env_file, override=False, interpolate=True)
+    else:
+        load_dotenv(override=False, interpolate=True)
+
+    _LOADED = True

--- a/app/main.py
+++ b/app/main.py
@@ -16,6 +16,9 @@ from app.api import files, entities, helpers, automations, scripts, system, back
 from app.utils.logger import setup_logger
 from app.ingress_panel import generate_ingress_html
 from app.services import ha_websocket
+from app.env import load_env
+load_env()
+
 from app.auth import verify_token, set_api_key, security
 
 # Setup logging
@@ -611,3 +614,4 @@ if __name__ == "__main__":
     import uvicorn
     port = int(os.getenv('PORT', 8099))
     uvicorn.run(app, host="0.0.0.0", port=port)
+


### PR DESCRIPTION
Load .env (or ENV_FILE) using python-dotenv with interpolation and ensure env vars are loaded before reads in main/auth. This enables .env usage for HA_AGENT_KEY/HA_AGENT_URL and supports indirection like HA_AGENT_KEY=\.