### PR TITLE
fix: resolve WebSocket reconnect cascade causing 30s timeout clusters

### DIFF
--- a/app/services/ha_websocket.py
+++ b/app/services/ha_websocket.py
@@ -91,12 +91,15 @@ class HAWebSocketClient:
         while self._running:
             try:
                 await self._connect_and_listen()
+                # Clean exit (server closed connection) — brief pause before reconnect
+                if self._running:
+                    await asyncio.sleep(1.0)
             except asyncio.CancelledError:
                 break
             except Exception as e:
                 logger.error(f"WebSocket connection error: {e}")
                 self._connected = False
-                
+
                 if self._running:
                     # Exponential backoff
                     logger.info(f"Reconnecting in {self._reconnect_delay} seconds...")
@@ -155,7 +158,14 @@ class HAWebSocketClient:
                 elif msg.type == aiohttp.WSMsgType.ERROR:
                     logger.error(f"WebSocket error: {ws.exception()}")
                     break
-            
+
+            # Fail all in-flight requests immediately instead of letting them
+            # wait 30s for a response that will never arrive
+            for msg_id, future in list(self.pending_requests.items()):
+                if not future.done():
+                    future.set_exception(ConnectionError("WebSocket disconnected"))
+            self.pending_requests.clear()
+
             self._connected = False
     
     async def _handle_message(self, data: dict):
@@ -376,11 +386,11 @@ class HAWebSocketClient:
     async def get_entity_registry_list(self) -> list:
         """
         Get all entities from Entity Registry
-        
+
         Returns:
             List of entity registry entries with metadata (area_id, device_id, name, etc.)
         """
-        result = await self._send_message({'type': 'config/entity_registry/list'})
+        result = await self._send_message({'type': 'config/entity_registry/list'}, timeout=90.0)
         return result or []
     
     async def get_entity_registry_entry(self, entity_id: str) -> dict:
@@ -628,11 +638,11 @@ class HAWebSocketClient:
     async def get_device_registry_list(self) -> list:
         """
         Get all devices from Device Registry
-        
+
         Returns:
             List of device registry entries
         """
-        result = await self._send_message({'type': 'config/device_registry/list'})
+        result = await self._send_message({'type': 'config/device_registry/list'}, timeout=90.0)
         return result or []
     
     async def get_device_registry_entry(self, device_id: str) -> dict:
@@ -751,11 +761,11 @@ async def get_ws_client() -> HAWebSocketClient:
         raise Exception("WebSocket client not initialized")
     
     if not ha_ws_client.is_connected:
-        # Try to wait for connection
+        # Wait for reconnect — 5s is too short during exponential backoff
         try:
-            await ha_ws_client.wait_for_connection(timeout=5.0)
+            await ha_ws_client.wait_for_connection(timeout=30.0)
         except TimeoutError:
-            raise Exception("WebSocket not connected. Agent may still be starting up.")
+            raise Exception("WebSocket not connected after 30s. HA may be restarting.")
     
     return ha_ws_client
 


### PR DESCRIPTION
## Problem

When the Home Assistant WebSocket connection drops (HA restart, watchdog action, or network blip), all in-flight `_send_message` calls wait the full 30-second timeout before failing. Multiple concurrent tool calls (entity registry list, automation listing, device registry, etc.) each independently time out, producing **clusters of errors spanning 2-5 minutes** after every disconnect.

The exact failure chain:
1. WS connection drops → `_connect_and_listen()` exits
2. `pending_requests` futures are never resolved (orphaned)
3. Each in-flight call hits `asyncio.TimeoutError` after 30s → `"WebSocket request timeout after 30.0s"`
4. Meanwhile, `get_ws_client()` only waits 5s for reconnect, which may not be enough during exponential backoff → `"WebSocket not connected"`

## Changes

### 1. Cancel orphaned futures immediately on disconnect
Instead of letting in-flight requests wait 30s for a response that will never arrive, we now fail them immediately with `ConnectionError("WebSocket disconnected")` when the WS connection closes. This collapses the 2-5 minute error cluster into a single instant failure burst.

### 2. Add 1s sleep on clean disconnect
When `_connect_and_listen` exits without exception (server closed the connection cleanly), the `_connection_loop` previously retried immediately with no pause, potentially causing a tight reconnect loop. Now waits 1 second before reconnecting.

### 3. Raise `get_ws_client` wait timeout from 5s to 30s
During exponential backoff (1s → 2s → 4s → 8s → ...), 5 seconds may not be enough to wait for reconnection. Raising to 30s ensures callers survive the backoff window instead of failing with "WebSocket not connected" during normal reconnection.

### 4. Raise registry list timeouts from 30s to 90s
`get_entity_registry_list()` and `get_device_registry_list()` return thousands of entries on real HA instances and can legitimately take longer than 30s under load. Raising to 90s prevents false timeout errors on healthy-but-busy systems.

## Testing

Observed this failure pattern across 6 consecutive infrastructure audits (10+ hours) on a production HA instance with 2200+ entities. The error clusters correlated perfectly with HA watchdog events visible in system logs.

After applying this patch:
- Disconnect failures should resolve in <1s instead of 30s
- Reconnection should succeed without callers failing during backoff
- Large registry queries should no longer time out on loaded systems